### PR TITLE
Fix mergify config to work with github actions.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,5 +7,8 @@ pull_request_rules:
   conditions:
   - label!=WIP
   - '#approved-reviews-by>=1'
-  - check-success=run tests
+  - check-success=test (3.6)
+  - check-success=test (3.7)
+  - check-success=test (3.8)
+  - check-success=test (3.9)
   name: default


### PR DESCRIPTION
Mergify needs to check success for each variation of a test
(in our case, python version in the name), so checking just
by the name we call it in the workflow is not sufficient.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>