### PR TITLE
Switch publish to build in the same way we manually build.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Upload Package to Pypi
 
 on:
   release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -18,11 +18,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install -r dist-requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
+        twine check dist/*
         twine upload dist/*


### PR DESCRIPTION
Also removed type restriction, this was preventing job from being
triggered, and add workflow_dispatch to allow manual triggering.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>