### PR TITLE
Use the same tox flake8 command on CI and locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,17 @@ jobs:
         - name: Run Tox
           # Run tox using the version of Python in `PATH`
           run: tox
-        - name: Lint with flake8
+    flake8:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.9
+        - name: Install Tox and any other packages
           run: |
-            pip install flake8
-            flake8 .
+            python -m pip install --upgrade pip
+            pip install tox tox-gh-actions
+        - name: Lint with flake8
+          run: tox -eflake8

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -38,10 +38,10 @@ def test_hash_with_config(mock_defaults_file):
     """
     url = 'http://foo.com/cgit'
     app = AppScaffold(config={
-                              'TESTING': True,
-                              'GIT_BASE_URL': url,
-                              'DEFAULTS_FILE': mock_defaults_file
-                             }).app
+        'TESTING': True,
+        'GIT_BASE_URL': url,
+        'DEFAULTS_FILE': mock_defaults_file
+    }).app
     assert app is not None
     assert app.config.get('GIT_BASE_URL') == url
     assert app.config.get('DEFAULTS_FILE') == mock_defaults_file


### PR DESCRIPTION
CI uses "flake8 ." while we have a "tox -eflake8" job that returns a different result and currently doesn't pass.

This patch removes the direct call to flake8 in the github action to replace it with a call to the existing tox environment and fixes an error currently returned by the tox job:

tests/unit/test_scaffold.py:41:31: E126 continuation line over-indented for hanging indent
tests/unit/test_scaffold.py:44:30: E126 continuation line over-indented for hanging indent

Additionally, make the flake8 CI job separate so that it is easier to understand if a unit test or lint job failed.
---
We could also simply remove the tox job and document the use of flake8 . instead, though I do like the convenience of having the full flake8 command "documented" as part of the tox config, it makes changes easier and only necessary in one place in the future.