### PR TITLE
Publish job was pointing at 'master', but we use 'main'.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Upload Package to Pypi and TestPyPI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Jason Guiditta <jguiditt@redhat.com>