### PR TITLE
Add tags to push event on publish action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: Upload Package to Pypi and TestPyPI
 on:
   push:
     branches: [ main ]
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The purpose of this is to try to get publish to pypi to work
with automation.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>