### PR TITLE
Implement configuration flexibility.

### DIFF
--- a/src/flask_container_scaffold/app_configurator.py
+++ b/src/flask_container_scaffold/app_configurator.py
@@ -1,0 +1,75 @@
+from flask_container_scaffold.util import load_yaml, load_cfg
+
+
+class AppConfigurator(object):
+
+    def __init__(self, app, relative=True):
+        """
+        This class handles loading and parsing of custom configuration
+        for your Flask app.
+
+        :param app obj: An existing Flask application
+        :param relative bool: Whether filenames found in configuration are
+            assumed to be relative to instance path rather than application
+            root.
+        """
+        self.app = app
+        self.relative = relative
+
+    def parse(self, custom):
+        """
+        Parse any custom configuration passed in for the app
+
+        :param custom obj: A String or dictionary to parse and add to the
+            application config.
+        """
+        if isinstance(custom, str):
+            self._parse_conf_item(custom)
+        elif isinstance(custom, dict):
+            for key in custom:
+                self.parse(custom[key])
+        else:
+            raise TypeError(f"{type(custom)} not currently supported")
+
+    def _parse_conf_item(self, item):
+        """
+        Check if the config item is a string pointing to a file.
+        If it is, and we support the filetype, call the appropriate
+        function to add the contents of the file to app.config object
+        """
+        supported_extensions = ['cfg', 'yaml', 'yml']
+        item_type = item.rsplit(".")[-1]
+        # If this is a file reference, and we support the type,
+        # detect the path, and the read the file and add the contents
+        # to the app config.
+        if item_type in supported_extensions:
+            item = self._detect_path(item)
+            self._add_to_config(item, item_type)
+        return item
+
+    def _detect_path(self, path):
+        """
+        When preparing to parse a file, determine if we have a explicit path
+        or if we are looking in the instance folder.
+        """
+        if path.startswith('/'):
+            pass
+        else:
+            if self.relative:
+                path = self.app.instance_path + path.replace('instance', '')
+            else:
+                path = self.app.instance_path + path
+
+        return path
+
+    def _add_to_config(self, file, file_type):
+        """
+        Call the appropriate parser based on filetype
+        """
+        current_dict = {}
+        if file_type in ['yaml', 'yml']:
+            current_dict = load_yaml(file)
+        elif file_type == 'cfg':
+            current_dict = load_cfg(file)
+        self.parse(current_dict)
+        self.app.config.update(current_dict)

--- a/src/flask_container_scaffold/util.py
+++ b/src/flask_container_scaffold/util.py
@@ -1,3 +1,5 @@
+import configparser
+
 from toolchest.yaml import parse
 
 
@@ -15,3 +17,31 @@ def load_yaml(filename='config.yml', logger=None):
     with open(filename, 'r') as file_handle:
         config = parse(file_handle, logger=logger)
     return config
+
+
+def load_cfg(conf_file):
+    """
+    Load a cfg file
+
+    :param conf_file str: A cfg/ini file to be parsed
+    :return: A dictionary formed out of the cfg file data
+    :raises: configparser.MissingSectionHeaderError, FileNotFoundError
+    """
+    config = configparser.ConfigParser()
+    # The following setting tells the parser not to alter the keys it
+    # has read in.  The default behavior converts these to lowercase:
+    # https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.optionxform
+    config.optionxform = lambda option: option
+    with open(conf_file) as conf:
+        config.read_file(conf)
+    return _parse_cfg(config)
+
+
+def _parse_cfg(config):
+    config_dict = {}
+    for section in config.sections():
+        settings_dict = {}
+        for key in config[section]:
+            settings_dict[key] = config[section][key]
+        config_dict.update({section: settings_dict})
+    return config_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,16 +9,55 @@ def config_defaults():
 
 
 @pytest.fixture
-def mock_defaults_file(config_defaults):
-    return os.path.join(config_defaults, 'data', 'config.yml')
+def mock_custom_only_folder(config_defaults):
+    return os.path.join(config_defaults, 'data', 'custom')
 
 
 @pytest.fixture
-def mock_settings_file(config_defaults):
+def mock_custom_only_settings_file(mock_custom_only_folder):
+    return os.path.join(mock_custom_only_folder, 'config.yml')
+
+
+@pytest.fixture
+def mock_custom_only_bad_file(mock_custom_only_folder):
+    return os.path.join(mock_custom_only_folder, 'bad_config.yml')
+
+
+@pytest.fixture
+def mock_custom_only_extra_cfg(mock_custom_only_folder):
+    return os.path.join(mock_custom_only_folder, 'extra.cfg')
+
+
+@pytest.fixture
+def mock_custom_only_cfg_w_includes(mock_custom_only_folder):
+    return os.path.join(mock_custom_only_folder, 'has_includes.cfg')
+
+
+@pytest.fixture
+def mock_instance_folder(config_defaults):
+    return os.path.join(config_defaults, 'data')
+
+
+@pytest.fixture
+def mock_flask_settings_file(config_defaults):
     return os.path.join(config_defaults, 'data', 'settings.cfg')
 
 
 @pytest.fixture
-def mock_env_vars(mock_settings_file, mock_defaults_file, monkeypatch):
-    monkeypatch.setenv('SETTINGS', mock_settings_file)
-    monkeypatch.setenv('DEFAULTS_FILE', mock_defaults_file)
+def mock_extra_settings_file(config_defaults):
+    return os.path.join(config_defaults, 'data', 'extra.cfg')
+
+
+@pytest.fixture
+def mock_custom_settings_file(config_defaults):
+    return os.path.join(config_defaults, 'data', 'config.yml')
+
+
+@pytest.fixture
+def mock_env_vars(mock_flask_settings_file, monkeypatch):
+    monkeypatch.setenv('FLASK_SETTINGS', mock_flask_settings_file)
+
+
+@pytest.fixture
+def mock_env_override_vars(mock_extra_settings_file, monkeypatch):
+    monkeypatch.setenv('FLASK_SETTINGS', mock_extra_settings_file)

--- a/tests/data/config.yml
+++ b/tests/data/config.yml
@@ -1,4 +1,5 @@
 ---
 
-a_key: 'some value'
+default_params:
+  a_key: 'some value'
 

--- a/tests/data/custom/bad_config.yml
+++ b/tests/data/custom/bad_config.yml
@@ -1,0 +1,3 @@
+---
+
+bad_path: '/some/path/fake.cfg'

--- a/tests/data/custom/config.yml
+++ b/tests/data/custom/config.yml
@@ -1,0 +1,6 @@
+---
+
+default_params:
+  a_key: 'another value'
+extra_config:
+  important_stuff: 'abc'

--- a/tests/data/custom/extra.cfg
+++ b/tests/data/custom/extra.cfg
@@ -1,0 +1,3 @@
+[custom_section]
+Different_case=val
+all_lower=something

--- a/tests/data/custom/has_includes.cfg
+++ b/tests/data/custom/has_includes.cfg
@@ -1,0 +1,5 @@
+[DEFAULT]
+more_yaml=instance/config.yml
+[my_config]
+one_key=foo
+two_key=bar

--- a/tests/data/extra.cfg
+++ b/tests/data/extra.cfg
@@ -1,0 +1,3 @@
+# Flask config files have a different format than standard cfg files
+ANOTHER_VALUE='I am so extra'
+RANDOM_VAL='baz'

--- a/tests/data/settings.cfg
+++ b/tests/data/settings.cfg
@@ -1,2 +1,6 @@
+# Flask does not currently support cfg section headers, and requires
+# strings to be in quotes even though python config parser does not.
+# Also, Flask will ignore any key not in CAPS
 GIT_BASE_URL='http://some.site/cgit/plain/additional-tags?h='
-DEFAULTS_FILE='instance/config.yml'
+CUSTOM_SETTINGS='instance/config.yml'
+RANDOM_VAL='farkle'

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -1,88 +1,262 @@
+import configparser
+
 import pytest
+from flask import Flask
+
 from flask_container_scaffold.app_scaffold import AppScaffold
 
-# Tests with testing config true:
+# Tests for base FLASK_SETTINGS
 
 
-def test_config_valid_settings_file(mock_env_vars):
+def test_no_config_valid_settings_file(mock_instance_folder):
     """
-    GIVEN a test mapping is passed to create_app
-    AND a valid SETTINGS and DEFAULTS_FILE env var is set
+    GIVEN no config is passed into app_scaffold
+    AND a valid settings.cfg file exists in the specified instance path
+    WHEN we create the app
+    THEN it creates an instance of the app
+    AND sets any values in the settings file
+    """
+    scaffold = AppScaffold(instance_path=mock_instance_folder)
+    url = 'http://some.site/cgit/plain/additional-tags?h='
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
+    assert scaffold.app.config.get('CUSTOM_SETTINGS') == 'instance/config.yml'
+    assert scaffold.app.config.get('RANDOM_VAL') == 'farkle'
+
+
+def test_settings_required_no_config_no_settings_file_no_env_setting():
+    """
+    GIVEN no config is passed into app_scaffold
+    AND no settings.cfg is in the expected location
+    AND we have not set FLASK_SETTINGS
+    AND settings_required=True
+    WHEN we create the app
+    THEN it raises a RuntimeError
+    """
+    with pytest.raises(RuntimeError):
+        AppScaffold(settings_required=True)
+
+
+def test_no_config_no_settings_file_no_env_setting():
+    """
+    GIVEN no config is passed into app_scaffold
+    AND no settings.cfg is in the expected location
+    AND we have not set FLASK_SETTINGS
+    AND we have left the default of settings_required=False
+    WHEN we create the app
+    THEN it creates the app with default settings.
+    """
+    app = AppScaffold()
+    assert app is not None
+
+
+def test_no_config_valid_settings_file_env_override(mock_instance_folder,
+                                                    mock_env_override_vars):
+    """
+    GIVEN no config is passed into app_scaffold
+    AND a valid settings.cfg file exists in the specified instance path
+    AND FLASK_SETTINGS points to a config file
+    WHEN we create the app
+    THEN it creates an instance of the app
+    AND sets any values in the settings file,
+    AND overrides existing values with those in the FLASK_SETTINGS file
+    """
+    scaffold = AppScaffold(instance_path=mock_instance_folder)
+    url = 'http://some.site/cgit/plain/additional-tags?h='
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
+    assert scaffold.app.config.get('CUSTOM_SETTINGS') == 'instance/config.yml'
+    assert scaffold.app.config.get('RANDOM_VAL') == 'baz'
+    assert scaffold.app.config.get('ANOTHER_VALUE') == 'I am so extra'
+
+
+def test_no_config_no_settings_file_valid_env_override(mock_env_vars,
+                                                       mock_instance_folder):
+    """
+    GIVEN no config is passed into app_scaffold
+    AND no settings.cfg is found
+    AND FLASK_SETTINGS points to a config file
+    WHEN we create the app
+    THEN it creates an instance of the app
+    AND sets any values in the FLASK_SETTINGS settings file
+    """
+    scaffold = AppScaffold(instance_path=mock_instance_folder)
+    url = 'http://some.site/cgit/plain/additional-tags?h='
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
+    assert scaffold.app.config.get('RANDOM_VAL') == 'farkle'
+
+
+def test_config_valid_settings_file(mock_instance_folder):
+    """
+    GIVEN a config mapping is passed to AppScaffold
+    AND a valid settings.cfg is found
     WHEN we try to create the app
     THEN it creates an instance of the app
     """
-    app = AppScaffold(config={'TESTING': True}).app
-    assert app is not None
+    scaffold = AppScaffold(config={'TESTING': True},
+                           instance_path=mock_instance_folder,
+                           settings_required=True)
     url = 'http://some.site/cgit/plain/additional-tags?h='
-    assert app.config.get('GIT_BASE_URL') == url
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
 
 
 def test_config_invalid_settings_file(monkeypatch):
     """
-    GIVEN a test mapping is passed to create_app
-    AND an invalid SETTINGS env var is set
+    GIVEN a config mapping is passed to AppScaffold
+    AND an invalid file is referenced by the FLASK_SETTINGS env var
     WHEN we try to create the app
     THEN it raises a FileNotFoundError
     """
-    monkeypatch.setenv('SETTINGS', '/some/path/fake.cfg')
+    monkeypatch.setenv('FLASK_SETTINGS', '/some/path/fake.cfg')
     with pytest.raises(FileNotFoundError):
         AppScaffold(config={'TESTING': True})
 
 
-def test_hash_with_config(mock_defaults_file):
+# Tests for CUSTOM SETTINGS
+
+def test_hash_with_config(mock_custom_only_settings_file,
+                          mock_custom_only_folder):
     """
-    GIVEN a test mapping is passed to create_app
+    GIVEN a config mapping is passed to AppScaffold
     AND it includes the required config values
     WHEN we try to create the app
     THEN it creates an instance of the app
     """
     url = 'http://foo.com/cgit'
-    app = AppScaffold(config={
-        'TESTING': True,
-        'GIT_BASE_URL': url,
-        'DEFAULTS_FILE': mock_defaults_file
-    }).app
-    assert app is not None
-    assert app.config.get('GIT_BASE_URL') == url
-    assert app.config.get('DEFAULTS_FILE') == mock_defaults_file
+    config = {'TESTING': True,
+              'CUSTOM_SETTINGS':
+              {'GIT_BASE_URL': url,
+               'DEFAULTS_FILE': mock_custom_only_settings_file}}
+    scaffold = AppScaffold(config=config,
+                           instance_path=mock_custom_only_folder)
+    assert scaffold.app is not None
+    custom_base = scaffold.app.config.get('CUSTOM_SETTINGS')
+    assert custom_base.get('GIT_BASE_URL') == url
+    assert custom_base.get('DEFAULTS_FILE') == mock_custom_only_settings_file
+    assert (scaffold.app.config.get('default_params').get('a_key') ==
+            'another value')
+    assert (scaffold.app.config.get('extra_config').get('important_stuff') ==
+            'abc')
 
 
 def test_hash_with_missing_config():
     """
-    GIVEN a test mapping is passed to create_app
+    GIVEN a config mapping is passed to AppScaffold
     AND it includes nothing else
+    AND settings_required=True
     WHEN we try to create the app
     THEN it fails to start the app
     AND throws an error to indicate missing config
     """
-    with pytest.raises(ValueError):
-        AppScaffold(config={'TESTING': True})
+    with pytest.raises(RuntimeError):
+        AppScaffold(config={'TESTING': True},
+                    settings_required=True)
 
 
-def test_setting_env_vars_directly_only(mock_defaults_file, monkeypatch):
+def test_setting_env_vars_directly_only(mock_custom_settings_file,
+                                        mock_flask_settings_file,
+                                        mock_instance_folder,
+                                        monkeypatch):
     """
-    GIVEN a test mapping is passed to create_app
+    GIVEN a config mapping is passed to AppScaffold
     AND the required config values are set as env vars
     WHEN we try to create the app
-    THEN it creates an instance of the app
+    THEN it creates an instance of the app with the expected setting
     """
-    url = 'http://foo.com/cgit'
-    monkeypatch.setenv('GIT_BASE_URL', url)
-    monkeypatch.setenv('DEFAULTS_FILE', mock_defaults_file)
-    app = AppScaffold(config={'TESTING': True}).app
-    assert app is not None
-    assert app.config.get('GIT_BASE_URL') == url
-    assert app.config.get('DEFAULTS_FILE') == mock_defaults_file
+    url = 'http://some.site/cgit/plain/additional-tags?h='
+    monkeypatch.setenv('FLASK_SETTINGS', mock_flask_settings_file)
+    monkeypatch.setenv('CUSTOM_SETTINGS', mock_custom_settings_file)
+    scaffold = AppScaffold(config={'TESTING': True},
+                           instance_path=mock_instance_folder)
+    assert scaffold.app is not None
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
+    assert (scaffold.app.config.get('CUSTOM_SETTINGS') ==
+            'instance/config.yml')
+    assert (scaffold.app.config.get('default_params').get('a_key') ==
+            'some value')
 
 
-def test_setting_incorrect_env_var(monkeypatch):
+def test_valid_instance_configs(mock_instance_folder):
     """
-    GIVEN a test mapping is passed to create_app
-    AND the wrong config values are set as env vars
+    GIVEN an existing Flask app
+    WHEN it is passed into the Scaffold
+    THEN the default settings in the specified instance folder are loaded
+    """
+    url = 'http://some.site/cgit/plain/additional-tags?h='
+    base_app = Flask('TestApp', instance_path=mock_instance_folder,
+                     instance_relative_config=True)
+    scaffold = AppScaffold(app=base_app)
+    assert scaffold.app is not None
+    assert scaffold.app.config.get('GIT_BASE_URL') == url
+    assert (scaffold.app.config.get('CUSTOM_SETTINGS') ==
+            'instance/config.yml')
+    assert (scaffold.app.config.get('default_params').get('a_key') ==
+            'some value')
+
+
+def test_loads_all_values_in_extra_cfg_file(mock_custom_only_extra_cfg):
+    """
+    GIVEN a config mapping is passed to AppScaffold
+    AND that mapping contains a custom setting pointing to a cfg file
     WHEN we try to create the app
-    THEN it fails to start the app
-    AND throws an error
+    THEN it creates an instance of the app with the expected setting
     """
-    monkeypatch.setenv('WRONG_KEY', 'http://foo.com/cgit')
-    with pytest.raises(ValueError):
-        AppScaffold(config={'TESTING': True})
+    scaffold = AppScaffold(config={
+        'TESTING': True,
+        'CUSTOM_SETTINGS': mock_custom_only_extra_cfg})
+    assert scaffold.app is not None
+    base_custom = scaffold.app.config.get('custom_section')
+    assert base_custom.get('Different_case') == 'val'
+    assert base_custom.get('all_lower') == 'something'
+
+
+def test_fails_on_bad_custom_cfg_format(mock_extra_settings_file):
+    """
+    GIVEN a config mapping is passed to AppScaffold
+    AND that mapping contains a custom setting pointing to an invalid cfg file
+    WHEN we try to create the app
+    THEN it raises a MissingSectionHeaderError
+    """
+    with pytest.raises(configparser.MissingSectionHeaderError):
+        AppScaffold(config={
+            'TESTING': True,
+            'CUSTOM_SETTINGS': mock_extra_settings_file})
+
+
+def test_referenced_config_file_not_found(mock_custom_only_bad_file):
+    """
+    GIVEN a config mapping is passed to AppScaffold
+    AND an invalid file is referenced by the FLASK_SETTINGS env var
+    WHEN we try to create the app
+    THEN it raises a FileNotFoundError
+    """
+    with pytest.raises(FileNotFoundError):
+        AppScaffold(config={
+            'TESTING': True,
+            'CUSTOM_SETTINGS': mock_custom_only_bad_file})
+
+
+def test_recursively_adds_config(mock_custom_only_cfg_w_includes,
+                                 mock_custom_only_folder):
+    """
+    GIVEN a config mapping is passed to AppScaffold
+    AND it includes a cfg file that in turn references another config file
+    WHEN we try to create the app
+    THEN it creates an instance of the app
+    AND sets values from both config files as expected
+    """
+    config = {'CUSTOM_SETTINGS': mock_custom_only_cfg_w_includes}
+    scaffold = AppScaffold(config=config,
+                           instance_path=mock_custom_only_folder)
+    assert scaffold.app is not None
+    # Check custom sections in cfg file were added:
+    assert (scaffold.app.config.get('my_config').get('one_key') ==
+            'foo')
+    assert (scaffold.app.config.get('my_config').get('two_key') ==
+            'bar')
+    # Check items in file referenced by first config were loaded:
+    assert (scaffold.app.config.get('default_params').get('a_key') ==
+            'another value')
+    assert (scaffold.app.config.get('extra_config').get('important_stuff') ==
+            'abc')
+    # Check that we do NOT have the path to the nested config file added
+    # to app.config
+    assert 'more_yaml' not in scaffold.app.config

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,27 @@
+import configparser
+
+import pytest
+
+from flask_container_scaffold.util import load_cfg
+
+
+def test_valid_cfg_file(mock_custom_only_extra_cfg):
+    """
+    GIVEN a valid cfg file
+    WHEN we try to load it
+    THEN we get back the expected python dict
+    """
+    expected = {'custom_section': {'Different_case': 'val',
+                                   'all_lower': 'something'}}
+    parsed = load_cfg(mock_custom_only_extra_cfg)
+    assert parsed == expected
+
+
+def test_invalid_cfg_file(mock_extra_settings_file):
+    """
+    GIVEN an invalid, Flask-style cfg file
+    WHEN we try to load it
+    THEN we get a MissingSectionHeaderError
+    """
+    with pytest.raises(configparser.MissingSectionHeaderError):
+        load_cfg(mock_extra_settings_file)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 passenv=HOME
 sitepackages = False
 commands =
-    flake8 --ignore=E501,W504 setup.py tests
+    flake8 --ignore=E501,W504 setup.py src tests
 
 [testenv:build]
 passenv =


### PR DESCRIPTION
Previously, this library supported a small, specific list of
configuration options.  This patch implements a more flexible, layered
approach.  We now take two levels of configuration, one for direct flask
configuration and adding thing to the app.config object as Flask would
typically do, and a second for custom configuration. This first version
supports custom configuration via cfg and yaml files, but in the future,
we can add support for others as needed (json, toml, etc).

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>