### PR TITLE
Split out tox dep so all ci jobs get it automatically.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-flask-container-scaffold = {path = ".",extras = ["test","dist"],editable = true}
+flask-container-scaffold = {path = ".",extras = ["devbase","test","dist"],editable = true}
 
 [packages]
 flask-container-scaffold = {path = ".",editable = true}

--- a/dist-requirements.txt
+++ b/dist-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .[dist]
+-e .[devbase,dist]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,12 @@ install_requires =
     toolchest
 
 [options.extras_require]
+devbase =
+    tox
 test =
     flake8
     pytest
     pytest-cov
-    tox
 dist =
     build
     setuptools_scm

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .[test]
+-e .[devbase,test]


### PR DESCRIPTION
By putting it in a different section, we can depend on tox for
both publish and test jobs.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>