### PR TITLE
Pass environment variable to tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,10 @@ commands =
     flake8 --ignore=E501,W504 setup.py tests
 
 [testenv:build]
-allowlist_externals = /bin/bash
+passenv =
+    SCM_NO_LOCAL_SCHEME
+allowlist_externals =
+    /bin/bash
 commands =
     /bin/bash tooling/build_changelog
     python -m build


### PR DESCRIPTION
Not sure how this ever worked for test-pypi, but we were not
passing the environment variable SCM_NO_LOCAL_SCHEME, which
tells setuptools_scm not to include the githash in the build
numbering.  If it is included, you cannot upload to pypi.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>