### PR TITLE
Fix parsing of config values.

### DIFF
--- a/src/flask_container_scaffold/app_configurator.py
+++ b/src/flask_container_scaffold/app_configurator.py
@@ -23,13 +23,11 @@ class AppConfigurator(object):
         :param obj custom: A String or dictionary to parse and add to the
             application config.
         """
-        if isinstance(custom, str):
-            self._parse_conf_item(custom)
-        elif isinstance(custom, dict):
+        if isinstance(custom, dict):
             for key in custom:
                 self.parse(custom[key])
         else:
-            raise TypeError(f"{type(custom)} not currently supported")
+            self._parse_conf_item(custom)
 
     def _parse_conf_item(self, item):
         """
@@ -38,7 +36,10 @@ class AppConfigurator(object):
         function to add the contents of the file to app.config object
         """
         supported_extensions = ['cfg', 'yaml', 'yml']
-        item_type = item.rsplit(".")[-1]
+        if isinstance(item, str):
+            item_type = item.rsplit(".")[-1]
+        else:
+            item_type = 'not a file'
         # If this is a file reference, and we support the type,
         # detect the path, and the read the file and add the contents
         # to the app config.

--- a/tests/data/config.yml
+++ b/tests/data/config.yml
@@ -2,4 +2,6 @@
 
 default_params:
   a_key: 'some value'
-
+  key_two: 3
+  a_list:
+    - list value

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -172,6 +172,9 @@ def test_setting_env_vars_directly_only(mock_custom_settings_file,
             'instance/config.yml')
     assert (scaffold.app.config.get('default_params').get('a_key') ==
             'some value')
+    assert scaffold.app.config.get('default_params').get('key_two') == 3
+    assert (scaffold.app.config.get('default_params').get('a_list') ==
+            ['list value'])
 
 
 def test_valid_instance_configs(mock_instance_folder):


### PR DESCRIPTION
Previously, when parsing the config passed in by the user, we
were artificially throwing an error if the value of a given key was
not a string or dictionary.  This check was to decide if further
parsing was needed to open an additional file specified in the config.
This patch fixes that logic so an error is not thrown when a value that
is neither string nor dictionary is passed in.

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>