### PR TITLE
Update github action versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,13 +34,13 @@ jobs:
       run:  tox -ebuild
     - name: Publish to Test PyPI
       if: startsWith(github.ref, 'refs/tags/') != true
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
         matrix:
           python: [3.6, 3.7, 3.8, 3.9]
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python }}
         - name: Install Tox and any other packages
@@ -25,9 +25,9 @@ jobs:
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: 3.9
         - name: Install Tox and any other packages
@@ -39,11 +39,11 @@ jobs:
     twine:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: 3.9
         - name: Install Tox and any other packages


### PR DESCRIPTION
For publish, master is no longer recommended or maintained,
so point the action at a release:
https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-
    
Release versions of checkout and python actions also needed to be
updated due to github changing the node they run on:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/


Signed-off-by: Jason Guiditta <jguiditt@redhat.com>