### PR TITLE
Update github action versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,13 +34,13 @@ jobs:
       run:  tox -ebuild
     - name: Publish to Test PyPI
       if: startsWith(github.ref, 'refs/tags/') != true
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: [3.6, 3.7, 3.8, 3.9]
+          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python }}
         - name: Install Tox and any other packages
@@ -25,11 +25,11 @@ jobs:
     flake8:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.9
+            python-version: 3.11
         - name: Install Tox and any other packages
           run: |
             python -m pip install --upgrade pip
@@ -39,13 +39,13 @@ jobs:
     twine:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
-            python-version: 3.9
+            python-version: 3.11
         - name: Install Tox and any other packages
           run: |
             python -m pip install --upgrade pip

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,10 +5,11 @@ queue_rules:
     conditions:
       # Conditions to get out of the queue (= merged)
       - check-success=flake8
-      - check-success=test (3.6)
       - check-success=test (3.7)
       - check-success=test (3.8)
       - check-success=test (3.9)
+      - check-success=test (3.10)
+      - check-success=test (3.11)
 
 pull_request_rules:
   - name: automatic merge
@@ -18,10 +19,11 @@ pull_request_rules:
       # We have to duplicate these because mergify won't allow us to use an
       # anchor
       - check-success=flake8
-      - check-success=test (3.6)
       - check-success=test (3.7)
       - check-success=test (3.8)
       - check-success=test (3.9)
+      - check-success=test (3.10)
+      - check-success=test (3.11)
     actions:
       queue:
         method: rebase

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}
+    py{37,38,39,310,311}
     flake8
 
 [testenv]


### PR DESCRIPTION
For publish, master is no longer recommended or maintained, so point the action at a release:
https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-

Release versions of checkout and python actions also needed to be updated due to github changing the node they run on: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Update supported versions of python, as we only went up to python 3.9, and 3.6 is now EOL:
https://devguide.python.org/versions/

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>