### PR TITLE
Remove deprecated configuration.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,5 @@ pull_request_rules:
     actions:
       queue:
         method: rebase
-        rebase_fallback: merge
         update_method: rebase
         name: default


### PR DESCRIPTION
The rebase_fallback option will be removed shortly, and is currently deprecated, so removing it from our configuration.

See docs here:
https://docs.mergify.com/actions/queue/#queue-action

Signed-off-by: Jason Guiditta <jguiditt@redhat.com>