### PR TITLE
Refactor FlaskRequestFormatter for easier reuse

### DIFF
--- a/src/flask_container_scaffold/network.py
+++ b/src/flask_container_scaffold/network.py
@@ -1,0 +1,24 @@
+from flask import request
+
+
+def get_ip_from_forwarded_field(field):
+    # RFC 7239 defines the following format for the Forwarded field:
+    # for=12.34.56.78;host=example.com;proto=https, for=23.45.67.89
+    # In testing, the first IP has consistently been the real user IP.
+    forwarded = field.split(",")[0]
+    for value in forwarded.split(";"):
+        if value.startswith("for="):
+            return value.split("=")[1]
+    else:
+        return None
+
+
+def get_remote_addr_from_flask():
+    # HTTP_FORWARDED seems to be the most reliable way to get the
+    # user real IP.
+    forwarded = request.environ.get('HTTP_FORWARDED')
+    if forwarded:
+        ip = get_ip_from_forwarded_field(forwarded)
+        return ip or request.remote_addr
+    else:
+        return request.remote_addr

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -82,3 +82,19 @@ def test_request_formatter_with_malformed_forwarded_field():
     with Flask("test").test_request_context(environ_base=env):
         formatter = FlaskRequestFormatter(FORMAT)
         assert formatter.format(record) == "[1.2.3.4] Test message"
+
+
+def test_request_formatter_with_remote_addr_already_set():
+    """
+    GIVEN a properly initialised FlaskRequestFormatter
+    WHEN it is called with a record that already has remote_addr set
+    THEN the log message contains that preset remote address
+    """
+    env = (("REMOTE_ADDR", "1.2.3.4"),
+           ("HTTP_FORWARDED", "host"),)
+    record = LogRecord('', 1, '', 1, 'Test message', '', None)
+    record.remote_addr = '1.1.1.1'
+
+    with Flask("test").test_request_context(environ_base=env):
+        formatter = FlaskRequestFormatter(FORMAT)
+        assert formatter.format(record) == "[1.1.1.1] Test message"


### PR DESCRIPTION
 * Move the function to get the forwarded IP to a network module, so they can be consistently reused by other callers
 * Allow the Formatter callers to optionally override the remote_addr