### PR TITLE
Fix configuration for rtd yaml file.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,16 @@
 # # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-   configuration: docs/conf.py
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
 python:
-    version: "3.8"
     install:
       - requirements: docs-requirements.txt
       - requirements: requirements.txt
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
There have been some changes to the yaml format since our docs last built, and there is now a 'build' section required. This updates our yaml to match the new requirement. See:

https://docs.readthedocs.io/en/stable/config-file/v2.html