### PR TITLE
Update sphinx to get docs building.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,10 +37,10 @@ test =
     pytest-cov
 
 docs =
-    sphinx==4.3.1
-    sphinx-autobuild==2021.3.14
-    sphinx-rtd-theme==0.5.2
-    myst-parser==0.15.2
+    sphinx
+    sphinx-autobuild
+    sphinx-rtd-theme
+    myst-parser
 
 dist =
     build

--- a/src/flask_container_scaffold/util.py
+++ b/src/flask_container_scaffold/util.py
@@ -57,6 +57,7 @@ def parse_input(logger, obj, default_return=BaseApiView):
     Parses incoming request, returns a serializable object to return
     to the client in all cases. When there is a failure, the
     object contains error information.
+
     :param Logger logger: Instantiated logger object
     :param BaseModel obj: An object type based on a pydantic BaseModel to
                           attempt to parse.


### PR DESCRIPTION
Latest RTD builds show an error saying we need at least sphinx 5.0.0, so starting with just using the latest and letting pip resolve versions.