### PR TITLE
Adding celery as a doc requirement.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-flask-container-scaffold = {path = ".",extras = ["devbase","test","docs","dist"],editable = true}
+flask-container-scaffold = {path = ".",extras = ["devbase","test","docs","dist","celery"],editable = true}
 
 [packages]
 flask-container-scaffold = {path = ".",editable = true}

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,2 @@
 -i https://pypi.python.org/simple
--e .[docs]
+-e .[docs,celery]

--- a/docs/flask_container_scaffold.rst
+++ b/docs/flask_container_scaffold.rst
@@ -8,7 +8,7 @@ AppConfigurator
    :show-inheritance:
 
 BaseScaffold
------------
+------------
 
 .. automodule:: flask_container_scaffold.base_scaffold
    :members:
@@ -26,7 +26,7 @@ AppScaffold
    :show-inheritance:
 
 CeleryScaffold
------------
+--------------
 
 .. automodule:: flask_container_scaffold.celery_scaffold
    :members:


### PR DESCRIPTION
Celery needs to be added to the docs requirements so that the documentation for CeleryScaffold is properly generated.

Also fixed up missing '-' in the main rst file.